### PR TITLE
fix resource quota error

### DIFF
--- a/pkg/framework/interface.go
+++ b/pkg/framework/interface.go
@@ -78,6 +78,10 @@ func (s *Status) Code() Code {
 	return s.code
 }
 
+func (s *Status) Message() string {
+	return s.message
+}
+
 // Plugin is the parent type for all the scheduling framework plugins.
 type Plugin interface {
 	Name() string

--- a/pkg/queue/schedulingqueue/priority_scheduling_queue.go
+++ b/pkg/queue/schedulingqueue/priority_scheduling_queue.go
@@ -22,10 +22,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/kubernetes/pkg/scheduler/util"
-
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 
 	"github.com/kube-queue/api/pkg/apis/scheduling/v1alpha1"
 	"github.com/kube-queue/kube-queue/pkg/framework"

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -83,6 +83,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 					}
 				}()
 			} else {
+				klog.Errorf("%v filter failed because %v", unitInfo.Name, status.Message())
 				s.ErrorFunc(ctx, unitInfo, q)
 			}
 			return


### PR DESCRIPTION
fix #35

Previous versions of resource quota cannot support resource quotas from different namespaces. Therefore, if one of the quotas runs out, it will prevent all jobs from being created.