### PR TITLE
fix kube-queue get priorityclass forbidden

### DIFF
--- a/charts/v0.0.1/templates/role/role.yaml
+++ b/charts/v0.0.1/templates/role/role.yaml
@@ -45,7 +45,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
kube-queue account get priorityclass forbidden