### PR TITLE
fix kube-queue get priorityclass forbidden

### DIFF
--- a/charts/v0.0.1/templates/role/role.yaml
+++ b/charts/v0.0.1/templates/role/role.yaml
@@ -43,7 +43,9 @@ rules:
   - apiGroups: [""]
     resources: ["resourcequotas"]
     verbs: ["get", "list", "watch"]
-
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
kube-queue account get priorityclass forbidden